### PR TITLE
feat!: exchange token doesn't redirect anymore

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -3,7 +3,6 @@ import passport from 'koa-passport';
 import { ExtractJwt, Strategy as JwtStrategy } from 'passport-jwt';
 
 import config from '../config';
-import { ForbiddenError } from '../errors';
 
 import c2cJwtExtractor from './c2c-jwt-extractor';
 import verify from './c2c-jwt-verify';
@@ -21,7 +20,7 @@ const ensureUserFromParamsMatchesAuthUser: Middleware = async (
     await next();
     return;
   }
-  throw new ForbiddenError();
+  ctx.throw(403);
 };
 
 passport.use(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,34 +1,28 @@
 import log from './helpers/logger';
 
 export class AppError extends Error {
-  public readonly code: number;
-  public readonly description?: string;
-
-  constructor(code: number, description?: string, cause?: Error, message?: string) {
+  constructor(public readonly code: number, message?: string, cause?: Error, public readonly body?: string) {
     super(message, { ...(cause && { cause }) });
-    if (description) {
-      this.message = description;
-    }
-    log.info(description);
+    log.warn(message);
     this.code = code;
   }
 }
 
 export class ExternalApiError extends AppError {
-  constructor(description: string, cause?: Error) {
-    super(502, description, cause);
+  constructor(message?: string, cause?: Error, body?: string) {
+    super(502, message, cause, body);
   }
 }
 
 export class NotFoundError extends AppError {
-  constructor(description?: string, cause?: Error) {
-    super(404, description, cause);
+  constructor(message?: string, cause?: Error, body?: string) {
+    super(404, message, cause, body);
   }
 }
 
 export class IOError extends AppError {
-  constructor(description: string, cause?: Error) {
-    super(500, description, cause);
+  constructor(message: string, cause?: Error, body?: string) {
+    super(500, message, cause, body);
   }
 }
 
@@ -39,13 +33,7 @@ export type FieldError = {
 };
 
 export class FieldValidationError extends AppError {
-  constructor(description: string, details: unknown, cause?: Error) {
-    super(400, description, cause, JSON.stringify(details, null, 2));
-  }
-}
-
-export class ForbiddenError extends AppError {
-  constructor() {
-    super(403);
+  constructor(message: string, details: unknown, cause?: Error) {
+    super(400, message, cause, JSON.stringify(details, null, 2));
   }
 }

--- a/src/server/decathlon/decathlon.controller.ts
+++ b/src/server/decathlon/decathlon.controller.ts
@@ -8,16 +8,15 @@ class DecathlonController {
     const c2cId = Number.parseInt(ctx['params'].userId, 10);
     if (ctx.query['error']) {
       ctx.log.info(`User ${c2cId} denied Decathlon authorization`);
-      ctx.redirect(`${service.subscriptionUrl}?error=auth-denied`);
-      return;
+      ctx.throw(403, 'auth-denied');
     }
 
     const authorizationCode = ctx.query['code'] as string;
     try {
       await service.requestShortLivedAccessTokenAndSetupUser(c2cId, authorizationCode);
-      ctx.redirect(service.subscriptionUrl);
+      ctx.status = 204;
     } catch (error: unknown) {
-      ctx.redirect(`${service.subscriptionUrl}?error=setup-failed`);
+      ctx.throw(502, 'setup-failed');
     }
   }
 

--- a/src/server/decathlon/decathlon.service.ts
+++ b/src/server/decathlon/decathlon.service.ts
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
 
-import config from '../../config';
 import { NotFoundError } from '../../errors';
 import log from '../../helpers/logger';
 import { promTokenRenewalErrorsCounter, promWebhookCounter, promWebhookErrorsCounter } from '../../metrics/prometheus';
@@ -15,12 +14,6 @@ import { Activity, decathlonApi, DecathlonAuth, WebhookEvent } from './decathlon
 import { sports } from './sports';
 
 export class DecathlonService {
-  public readonly subscriptionUrl: string;
-
-  constructor() {
-    this.subscriptionUrl = config.get('c2c.frontend.baseUrl') + config.get('c2c.frontend.subscriptionPath');
-  }
-
   public async requestShortLivedAccessTokenAndSetupUser(c2cId: number, authorizationCode: string): Promise<void> {
     const auth = await decathlonApi.exchangeToken(authorizationCode);
     await this.setupUser(c2cId, auth);

--- a/src/server/error-handler.ts
+++ b/src/server/error-handler.ts
@@ -1,5 +1,5 @@
 import type { Middleware } from '@koa/router';
-import type { Context } from 'koa';
+import { Context, HttpError } from 'koa';
 
 import { AppError } from '../errors';
 import log from '../helpers/logger';
@@ -11,7 +11,11 @@ export function defaultErrorHandler(): Middleware {
       await next();
     } catch (error: unknown) {
       if (error instanceof AppError) {
+        ctx.body = error.body;
         ctx.status = error.code;
+      } else if (error instanceof HttpError) {
+        ctx.body = error.message;
+        ctx.status = error.status;
       } else {
         log.warn(error, 'Unhandled error');
         promUnhandledErrorsCounter.inc(1);

--- a/src/server/garmin/garmin.controller.ts
+++ b/src/server/garmin/garmin.controller.ts
@@ -32,23 +32,21 @@ class GarminController {
 
     if (verifier.toLocaleLowerCase() === 'null') {
       ctx.log.info(`User ${c2cId} denied Garmin authorization`);
-      ctx.redirect(`${service.subscriptionUrl}?error=auth-denied`);
-      return;
+      ctx.throw(403, 'auth-denied');
     }
 
     const tokenSecret = (await this.keyv.get(c2cId.toString())) as string;
     if (!tokenSecret) {
       ctx.log.info(`No token secret found in mem for user ${c2cId}: unable to request Garmin access token`);
-      ctx.redirect(`${service.subscriptionUrl}?error=setup-failed`);
-      return;
+      ctx.throw(502, 'setup-failed');
     }
 
     try {
       await service.requestAccessTokenAndSetupUser(c2cId, token, tokenSecret, verifier);
-      ctx.redirect(service.subscriptionUrl);
+      ctx.status = 204;
     } catch (error: unknown) {
       ctx.log.info(error);
-      ctx.redirect(`${service.subscriptionUrl}?error=setup-failed`);
+      ctx.throw(502, 'setup-failed');
     }
   }
 

--- a/src/server/garmin/garmin.service.ts
+++ b/src/server/garmin/garmin.service.ts
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import dayjsPluginUTC from 'dayjs/plugin/utc';
 
-import config from '../../config';
 import { NotFoundError } from '../../errors';
 import log from '../../helpers/logger';
 import { promWebhookCounter, promWebhookErrorsCounter } from '../../metrics/prometheus';
@@ -17,12 +16,6 @@ import { GarminActivity, garminApi, GarminAuth, GarminSample } from './garmin.ap
 dayjs.extend(dayjsPluginUTC);
 
 export class GarminService {
-  public readonly subscriptionUrl: string;
-
-  constructor() {
-    this.subscriptionUrl = config.get('c2c.frontend.baseUrl') + config.get('c2c.frontend.subscriptionPath');
-  }
-
   public async requestUnauthorizedRequestToken(): Promise<GarminAuth> {
     return await garminApi.requestUnauthorizedRequestToken();
   }

--- a/src/server/strava/strava.service.ts
+++ b/src/server/strava/strava.service.ts
@@ -17,11 +17,9 @@ import { Activity, StravaAuth, stravaApi, WebhookEvent, Subscription, StreamSet 
 const webhookCallbackUrl = `${config.get('server.baseUrl')}strava/webhook`;
 
 export class StravaService {
-  public readonly subscriptionUrl: string;
   public readonly stravaWebhookSubscriptionVerifyToken: string;
 
   constructor() {
-    this.subscriptionUrl = config.get('c2c.frontend.baseUrl') + config.get('c2c.frontend.subscriptionPath');
     this.stravaWebhookSubscriptionVerifyToken = config.get('trackers.strava.webhookSubscriptionVerifyToken');
   }
 

--- a/src/server/suunto/suunto.controller.ts
+++ b/src/server/suunto/suunto.controller.ts
@@ -8,17 +8,16 @@ class SuuntoController {
     const c2cId = Number.parseInt(ctx['params'].userId, 10);
     if (ctx.query['error']) {
       ctx.log.info(`User ${c2cId} denied Suunto authorization`);
-      ctx.redirect(`${service.subscriptionUrl}?error=auth-denied`);
-      return;
+      ctx.throw(403, 'auth-denied');
     }
     const authorizationCode = ctx.query['code'] as string;
 
     try {
       await service.requestShortLivedAccessTokenAndSetupUser(c2cId, authorizationCode);
-      ctx.redirect(service.subscriptionUrl);
+      ctx.status = 204;
     } catch (error: unknown) {
       ctx.log.info(error);
-      ctx.redirect(`${service.subscriptionUrl}?error=setup-failed`);
+      ctx.throw(502, 'setup-failed');
     }
   }
 

--- a/src/server/suunto/suunto.service.ts
+++ b/src/server/suunto/suunto.service.ts
@@ -15,12 +15,10 @@ import { SuuntoAuth, Workouts, workoutTypes, WebhookEvent, suuntoApi, WorkoutSum
 dayjs.extend(dayjsPluginUTC);
 
 export class SuuntoService {
-  public readonly subscriptionUrl: string;
   readonly #suuntoSubscriptionKey: string;
   readonly #suuntoWebhookSubscriptionToken: string;
 
   constructor() {
-    this.subscriptionUrl = config.get('c2c.frontend.baseUrl') + config.get('c2c.frontend.subscriptionPath');
     this.#suuntoSubscriptionKey = config.get('trackers.suunto.subscriptionKey');
     this.#suuntoWebhookSubscriptionToken = config.get('trackers.suunto.webhookSubscriptionToken');
   }

--- a/test/unit/auth/index.spec.ts
+++ b/test/unit/auth/index.spec.ts
@@ -1,7 +1,6 @@
 import { createMockContext } from '@shopify/jest-koa-mocks';
 
 import { ensureAuthenticated, ensureUserFromParamsMatchesAuthUser, passport } from '../../../src/auth';
-import { ForbiddenError } from '../../../src/errors';
 import log from '../../../src/helpers/logger';
 import { AuthenticatedUserStrategy } from '../../utils';
 
@@ -44,10 +43,11 @@ describe('ensureUserFromParamsMatchesAuthUser', () => {
       customProperties: {
         params: { userId: '123' },
       },
+      throw: jest.fn(),
     });
-    await expect(ensureUserFromParamsMatchesAuthUser(ctx, async () => undefined)).rejects.toBeInstanceOf(
-      ForbiddenError,
-    );
+    await ensureUserFromParamsMatchesAuthUser(ctx, async () => undefined);
+    expect(ctx.throw).toBeCalledTimes(1);
+    expect(ctx.throw).toBeCalledWith(403);
   });
 
   it('rejects un-authenticated user', async () => {
@@ -56,9 +56,10 @@ describe('ensureUserFromParamsMatchesAuthUser', () => {
       customProperties: {
         params: { userId: '123' },
       },
+      throw: jest.fn(),
     });
-    await expect(ensureUserFromParamsMatchesAuthUser(ctx, async () => undefined)).rejects.toBeInstanceOf(
-      ForbiddenError,
-    );
+    await ensureUserFromParamsMatchesAuthUser(ctx, async () => undefined);
+    expect(ctx.throw).toBeCalledTimes(1);
+    expect(ctx.throw).toBeCalledWith(403);
   });
 });

--- a/test/unit/server/decathlon/decathlon.controller.spec.ts
+++ b/test/unit/server/decathlon/decathlon.controller.spec.ts
@@ -46,13 +46,11 @@ describe('Decathlon Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"http://localhost:8080/external-services?error=auth-denied"`,
-      );
+      expect(response.status).toBe(403);
+      expect(response.text).toEqual('auth-denied');
     });
 
-    it('redirects if user setup fails', async () => {
+    it('throws if user setup fails', async () => {
       jest.spyOn(decathlonService, 'requestShortLivedAccessTokenAndSetupUser').mockRejectedValueOnce(undefined);
 
       const response = await authenticated(
@@ -62,13 +60,11 @@ describe('Decathlon Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"http://localhost:8080/external-services?error=setup-failed"`,
-      );
+      expect(response.status).toBe(502);
+      expect(response.text).toEqual('setup-failed');
     });
 
-    it('setups user and redirects', async () => {
+    it('setups user', async () => {
       jest.spyOn(decathlonService, 'requestShortLivedAccessTokenAndSetupUser').mockResolvedValueOnce(undefined);
 
       const response = await authenticated(
@@ -78,8 +74,7 @@ describe('Decathlon Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toEqual(decathlonService.subscriptionUrl);
+      expect(response.status).toBe(204);
       expect(decathlonService.requestShortLivedAccessTokenAndSetupUser).toBeCalledTimes(1);
       expect(decathlonService.requestShortLivedAccessTokenAndSetupUser).toBeCalledWith(1, 'longenoughcode');
     });

--- a/test/unit/server/strava/strava.controller.spec.ts
+++ b/test/unit/server/strava/strava.controller.spec.ts
@@ -48,25 +48,21 @@ describe('Strava Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"http://localhost:8080/external-services?error=auth-denied"`,
-      );
+      expect(response.status).toBe(403);
+      expect(response.text).toEqual('auth-denied');
     });
 
-    it('redirects if unsufficient scopes are accepted', async () => {
+    it('throws if unsufficient scopes are accepted', async () => {
       const response = await authenticated(
         request(app.callback()).get('/strava/exchange-token/1').query({ code: 'longenoughcode', scope: 'toto' }),
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"http://localhost:8080/external-services?error=unsufficient-scopes"`,
-      );
+      expect(response.status).toBe(403);
+      expect(response.text).toEqual('unsufficient-scopes');
     });
 
-    it('redirects if user setup fails', async () => {
+    it('throws if user setup fails', async () => {
       jest.spyOn(stravaService, 'requestShortLivedAccessTokenAndSetupUser').mockRejectedValueOnce(undefined);
 
       const response = await authenticated(
@@ -76,13 +72,11 @@ describe('Strava Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"http://localhost:8080/external-services?error=setup-failed"`,
-      );
+      expect(response.status).toBe(502);
+      expect(response.text).toEqual('setup-failed');
     });
 
-    it('setups user and redirects', async () => {
+    it('setups user', async () => {
       jest.spyOn(stravaService, 'requestShortLivedAccessTokenAndSetupUser').mockResolvedValueOnce(undefined);
 
       const response = await authenticated(
@@ -92,8 +86,7 @@ describe('Strava Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toEqual(stravaService.subscriptionUrl);
+      expect(response.status).toBe(204);
       expect(stravaService.requestShortLivedAccessTokenAndSetupUser).toBeCalledTimes(1);
       expect(stravaService.requestShortLivedAccessTokenAndSetupUser).toBeCalledWith(1, 'longenoughcode');
     });

--- a/test/unit/server/suunto/suunto.controller.spec.ts
+++ b/test/unit/server/suunto/suunto.controller.spec.ts
@@ -45,13 +45,11 @@ describe('Suunto Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"http://localhost:8080/external-services?error=auth-denied"`,
-      );
+      expect(response.status).toBe(403);
+      expect(response.text).toEqual('auth-denied');
     });
 
-    it('redirects if user setup fails', async () => {
+    it('throws if user setup fails', async () => {
       jest.spyOn(suuntoService, 'requestShortLivedAccessTokenAndSetupUser').mockRejectedValueOnce(undefined);
 
       const response = await authenticated(
@@ -59,13 +57,11 @@ describe('Suunto Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"http://localhost:8080/external-services?error=setup-failed"`,
-      );
+      expect(response.status).toBe(502);
+      expect(response.text).toEqual('setup-failed');
     });
 
-    it('setups user and redirects', async () => {
+    it('setups user', async () => {
       jest.spyOn(suuntoService, 'requestShortLivedAccessTokenAndSetupUser').mockResolvedValueOnce(undefined);
 
       const response = await authenticated(
@@ -73,8 +69,7 @@ describe('Suunto Controller', () => {
         1,
       );
 
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toEqual(suuntoService.subscriptionUrl);
+      expect(response.status).toBe(204);
       expect(suuntoService.requestShortLivedAccessTokenAndSetupUser).toBeCalledTimes(1);
       expect(suuntoService.requestShortLivedAccessTokenAndSetupUser).toBeCalledWith(1, 'longenoughcode');
     });


### PR DESCRIPTION
Because authentication is done through Bearer Authoriztion header, the UI cannot call exchange-token and listen to redirection. Instead, it must be an XHR call and the return status & message must be taken into account.

In the meantime, do some cleanup...

BREAKING CHANGE