### PR TITLE
fix: Garmin connection process

### DIFF
--- a/src/server/garmin/garmin.controller.ts
+++ b/src/server/garmin/garmin.controller.ts
@@ -1,17 +1,13 @@
 import Keyv from 'keyv';
 import type { Context } from 'koa';
 
-import config from '../../config';
-
 import type { GarminActivity } from './garmin.api';
 import { garminService as service } from './garmin.service';
 
 class GarminController {
-  private readonly exchangeTokenUrl;
   private readonly keyv;
 
   constructor() {
-    this.exchangeTokenUrl = `${config.get('server.baseUrl')}garmin/exchange-token`;
     this.keyv = new Keyv();
   }
 
@@ -19,9 +15,8 @@ class GarminController {
     const c2cId = Number.parseInt(ctx['params'].userId, 10);
     const { token, tokenSecret } = await service.requestUnauthorizedRequestToken();
     await this.keyv.set(c2cId.toString(), tokenSecret, 1000 * 60 * 60); // 1 hour TTL
-    ctx.redirect(
-      `https://connect.garmin.com/oauthConfirm?oauth_token=${token}&oauth_callback=${this.exchangeTokenUrl}/${c2cId}`,
-    );
+    ctx.body = { token };
+    ctx.status = 200;
   }
 
   public async exchangeToken(ctx: Context): Promise<void> {

--- a/test/unit/server/garmin/garmin.controller.spec.ts
+++ b/test/unit/server/garmin/garmin.controller.spec.ts
@@ -30,7 +30,7 @@ describe('Garmin Controller', () => {
       expect(response.status).toBe(403);
     });
 
-    it('stores retrieved token secret in memory with 1 hour TTL and redirects', async () => {
+    it('stores retrieved token secret in memory with 1 hour TTL and returns token', async () => {
       jest
         .spyOn(garminService, 'requestUnauthorizedRequestToken')
         .mockResolvedValueOnce({ token: 'token', tokenSecret: 'tokenSecret' });
@@ -38,10 +38,7 @@ describe('Garmin Controller', () => {
       const response = await authenticated(request(app.callback()).get('/garmin/request-token/1'), 1);
 
       expect(await (garminController['keyv'] as Keyv).get('1')).toBe('tokenSecret');
-      expect(response.redirect).toBeTruthy();
-      expect(response.headers['location']).toMatchInlineSnapshot(
-        `"https://connect.garmin.com/oauthConfirm?oauth_token=token&oauth_callback=http://localhost:3000/garmin/exchange-token/1"`,
-      );
+      expect(response.body).toEqual({ token: 'token' });
     });
   });
 


### PR DESCRIPTION
Do not redirect. Instead, return token. UI side is responsible for calling Garmin OAuth.