### PR TITLE
feat: allow to configure payload size limit

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -81,7 +81,11 @@ app
       origin: config.get('c2c.frontend.baseUrl').slice(0, -1),
     }),
   )
-  .use(bodyParser())
+  .use(
+    bodyParser({
+      jsonLimit: config.get('server.payload.limit'),
+    }),
+  )
   .use(helmet())
   .use(rTracer.koaMiddleware())
   .use(

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,14 @@ const config = convict({
       env: 'PORT',
       arg: 'port',
     },
+    payload: {
+      limit: {
+        doc: 'The JSON payload size limit',
+        format: 'notEmptyString',
+        default: '50mb',
+        env: 'SERVER_PAYLOAD_MAX_SIZE',
+      },
+    },
     baseUrl: {
       doc: 'Base URL the server binds to',
       format: 'baseUrl',


### PR DESCRIPTION
and use default at 50mb instead of 1mb (because of garmin backfill)